### PR TITLE
Build against debug libraries on Windows

### DIFF
--- a/crates/qt-build-utils/src/lib.rs
+++ b/crates/qt-build-utils/src/lib.rs
@@ -45,7 +45,22 @@ pub enum QtBuildError {
     QtMissing,
     /// Executing `qmake -query` failed
     #[error("Executing `qmake -query` failed: {0:?}")]
-    QmakeFailed(#[from] std::io::Error),
+    RunQmakeFailed(#[from] std::io::Error),
+    /// qmake returned non-zero
+    #[error("`qmake -query` returned nonzero: {stdout}")]
+    QmakeFailed {
+        /// The decoded stdout of the command
+        stdout : String
+    },
+    /// decoding qmake output failed
+    #[error("Decoding `qmake -query` output failed: {0:?}")]
+    DecodeQmakeOutputFailed(#[from] core::str::Utf8Error),
+    /// Parsing qmake output failed
+    #[error("Parsing `qmake -query` output failed: {stdout}")]
+    ParseQmakeOutputFailed {
+        /// The decoded stdout of the command
+        stdout : String
+    },
     /// `QT_VERSION_MAJOR` environment variable was specified but could not be parsed as an integer
     #[error("QT_VERSION_MAJOR environment variable specified as {qt_version_major_env_var} but could not parse as integer: {source:?}")]
     QtVersionMajorInvalid {
@@ -73,6 +88,11 @@ fn is_apple_target() -> bool {
     env::var("TARGET")
         .map(|target| target.contains("apple"))
         .unwrap_or_else(|_| false)
+}
+
+/// Whether windows is the current host
+fn is_windows_host() -> bool {
+    cfg!(target_os = "windows")
 }
 
 /// Linking executables (including tests) with Cargo that link to Qt fails to link with GNU ld.bfd,
@@ -282,48 +302,38 @@ impl QtBuild {
         println!("cargo::rerun-if-env-changed=QMAKE");
         println!("cargo::rerun-if-env-changed=QT_VERSION_MAJOR");
         fn verify_candidate(candidate: &str) -> Result<(&str, versions::SemVer), QtBuildError> {
-            match Command::new(candidate)
-                .args(["-query", "QT_VERSION"])
-                .output()
+            match QtBuild::qmake_query_explicit(candidate, "QT_VERSION")
             {
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(QtBuildError::QtMissing),
-                Err(e) => Err(QtBuildError::QmakeFailed(e)),
-                Ok(output) => {
-                    if output.status.success() {
-                        let version_string = std::str::from_utf8(&output.stdout)
-                            .unwrap()
-                            .trim()
-                            .to_string();
-                        let qmake_version = versions::SemVer::new(version_string).unwrap();
-                        if let Ok(env_version) = env::var("QT_VERSION_MAJOR") {
-                            let env_version = match env_version.trim().parse::<u32>() {
-                                Err(e) if *e.kind() == std::num::IntErrorKind::Empty => {
-                                    println!(
-                                        "cargo::warning=QT_VERSION_MAJOR environment variable defined but empty"
-                                    );
-                                    return Ok((candidate, qmake_version));
-                                }
-                                Err(e) => {
-                                    return Err(QtBuildError::QtVersionMajorInvalid {
-                                        qt_version_major_env_var: env_version,
-                                        source: e,
-                                    })
-                                }
-                                Ok(int) => int,
-                            };
-                            if env_version == qmake_version.major {
+                Err(e) => Err(e),
+                Ok(version_string) => {
+                    let qmake_version = versions::SemVer::new(&version_string)
+                       .ok_or(QtBuildError::ParseQmakeOutputFailed { stdout: version_string })?;
+                    if let Ok(env_version) = env::var("QT_VERSION_MAJOR") {
+                        let env_version = match env_version.trim().parse::<u32>() {
+                            Err(e) if *e.kind() == std::num::IntErrorKind::Empty => {
+                                println!(
+                                    "cargo::warning=QT_VERSION_MAJOR environment variable defined but empty"
+                                );
                                 return Ok((candidate, qmake_version));
-                            } else {
-                                return Err(QtBuildError::QtVersionMajorDoesNotMatch {
-                                    qmake_version: qmake_version.major,
-                                    qt_version_major: env_version,
-                                });
                             }
+                            Err(e) => {
+                                return Err(QtBuildError::QtVersionMajorInvalid {
+                                    qt_version_major_env_var: env_version,
+                                    source: e,
+                                })
+                            }
+                            Ok(int) => int,
+                        };
+                        if env_version == qmake_version.major {
+                            return Ok((candidate, qmake_version));
+                        } else {
+                            return Err(QtBuildError::QtVersionMajorDoesNotMatch {
+                                qmake_version: qmake_version.major,
+                                qt_version_major: env_version,
+                            });
                         }
-                        Ok((candidate, qmake_version))
-                    } else {
-                        Err(QtBuildError::QtMissing)
                     }
+                    Ok((candidate, qmake_version))
                 }
             }
         }
@@ -390,18 +400,42 @@ impl QtBuild {
         Err(QtBuildError::QtMissing)
     }
 
-    /// Get the output of running `qmake -query var_name`
+    /// Attempt to get the output of running `qmake -query var_name`.
+    pub fn qmake_query_explicit(qmake_executable: &str,
+                                var_name: &str) -> Result<String, QtBuildError> {
+        let shell_command = format!("{} -query {}", qmake_executable, var_name);
+        let command_output =
+            if is_windows_host() {
+                Command::new("cmd").args(["/C", &shell_command]).output()
+            } else {
+                Command::new("sh").args(["-c", &shell_command]).output()
+            };
+
+        match command_output {
+            Ok(output) => {
+                let output_string : String;
+                match std::str::from_utf8(&output.stdout)
+                {
+                    Ok(s) => { output_string = s.trim().to_string() },
+                    Err(e) => { return Err(QtBuildError::DecodeQmakeOutputFailed(e)); }
+                }
+                if !output.status.success() {
+                    return Err(QtBuildError::QmakeFailed { stdout: output_string });
+                } else if output.stdout.is_empty() {
+                    return Err(QtBuildError::ParseQmakeOutputFailed { stdout: "".to_string() });
+                }
+                Ok(output_string)
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(QtBuildError::QtMissing),
+            Err(e) => Err(QtBuildError::RunQmakeFailed(e)),
+        }
+    }
+
+    /// Query the qmake executable which was previously
+    /// verified. Panic on error.
     pub fn qmake_query(&self, var_name: &str) -> String {
-        std::str::from_utf8(
-            &Command::new(&self.qmake_executable)
-                .args(["-query", var_name])
-                .output()
-                .unwrap()
-                .stdout,
-        )
-        .unwrap()
-        .trim()
-        .to_string()
+        Self::qmake_query_explicit(&self.qmake_executable, var_name)
+            .unwrap()
     }
 
     fn cargo_link_qt_library(
@@ -439,7 +473,7 @@ impl QtBuild {
     }
 
     /// Some prl files include their architecture in their naming scheme.
-    /// Just try all known architectures and fallback to non when they all failed.
+    /// Just try all known architectures and fallback to non if they all failed.
     fn find_qt_module_prl(
         &self,
         lib_path: &str,


### PR DESCRIPTION
(draft)

on Windows, when Qt is built in debug mode, the DLLs/PRLs get a suffix. Auto-detect this and build against it.